### PR TITLE
Refactor contract event filter

### DIFF
--- a/lib/types/coder.js
+++ b/lib/types/coder.js
@@ -31,6 +31,7 @@ var TypeString = require('./string');
 var TypeReal = require('./real');
 var TypeUReal = require('./ureal');
 var TypeBytes = require('./bytes');
+var sha3 = require('../utils/sha3')
 
 var isDynamic = function (Type, type) {
    return Type.isDynamicType(type) ||
@@ -72,8 +73,11 @@ Coder.prototype._requireType = function (type) {
  * @param {Object} plain param
  * @return {String} encoded plain param
  */
-Coder.prototype.encodeParam = function (type, param) {
-    return this.encodeParams([type], [param]);
+Coder.prototype.encodeParam = function (type, param, indexed=false) {
+    if(type === "string" && indexed) {
+        return sha3(param)
+    }
+    return this.encodeParams([type], [param], indexed);
 };
 
 /**
@@ -84,7 +88,7 @@ Coder.prototype.encodeParam = function (type, param) {
  * @param {Array} params
  * @return {String} encoded list of params
  */
-Coder.prototype.encodeParams = function (types, params) {
+Coder.prototype.encodeParams = function (types, params, indexed=false) {
     var Types = this.getTypes(types);
 
     var encodeds = Types.map(function (Type, index) {
@@ -187,8 +191,8 @@ Coder.prototype.encodeWithOffset = function (type, Type, encoded, offset) {
  * @param {String} bytes
  * @return {Object} plain param
  */
-Coder.prototype.decodeParam = function (type, bytes) {
-    return this.decodeParams([type], bytes)[0];
+Coder.prototype.decodeParam = function (type, bytes, indexed=false) {
+    return this.decodeParams([type], bytes, indexed)[0];
 };
 
 /**
@@ -204,7 +208,7 @@ Coder.prototype.decodeParams = function (types, bytes, indexed=false) {
     var offsets = this.getOffsets(types, Types);
 
     return Types.map(function (Type, index) {
-        return Type.decode(bytes, offsets[index],  types[index], indexed);
+        return Type.decode(bytes, offsets[index], types[index], indexed);
     });
 };
 

--- a/lib/types/formatters.js
+++ b/lib/types/formatters.js
@@ -218,7 +218,8 @@ var formatOutputDynamicBytes = function (param) {
  */
 var formatOutputString = function (param, name, indexed=false) {
     if(indexed) {
-        return utils.toUtf8(param.value)
+        // return utils.toUtf8(param.value)
+        return ""
     }
     var length = (new BigNumber(param.dynamicPart().slice(0, 64), 16)).toNumber() * 2;
     return utils.toUtf8(param.dynamicPart().substr(64, length));

--- a/lib/vnt/event.js
+++ b/lib/vnt/event.js
@@ -119,10 +119,10 @@ Event.prototype.encode = function (indexed, options) {
 
         if (utils.isArray(value)) {
             return value.map(function (v) {
-                return '0x' + coder.encodeParam(i.type, v);
+                return '0x' + coder.encodeParam(i.type, v, true);
             });
         }
-        return '0x' + coder.encodeParam(i.type, value);
+        return '0x' + coder.encodeParam(i.type, value, true);
     });
 
     result.topics = result.topics.concat(indexedTopics);
@@ -177,9 +177,21 @@ Event.prototype.execute = function (indexed, options, callback) {
 
     if (utils.isFunction(arguments[arguments.length - 1])) {
         callback = arguments[arguments.length - 1];
-        if(arguments.length === 2)
+        if(arguments.length === 2){
+            options = arguments[0];
+            indxed = {}
+        } else if(arguments.length === 1) {
             options = null;
-        if(arguments.length === 1) {
+            indexed = {};
+        }
+    } else {
+        if(arguments.length === 2){
+            options = arguments[1];
+            indxed = arguments[0];
+        } else if(arguments.length === 1) {
+            options = arguments[0];
+            indexed = {};
+        } else {
             options = null;
             indexed = {};
         }


### PR DESCRIPTION
The event filter does not works for string indexed filter, this
change uses sha3 value of the string value to filter the event
logs, which were stored on the block.